### PR TITLE
Add complex number theorems and build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .aider*
+
+**/.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 .aider*
-
-**/.claude/settings.local.json

--- a/build/complex.yaml
+++ b/build/complex.yaml
@@ -1,5 +1,5 @@
 dependencies: 7660433881943572148
-content: 16486769998771420253
+content: 13078576831410691947
 blocks:
   abs_squared_conj:
     complex:
@@ -11,7 +11,6 @@ blocks:
     - Complex.re
     real:
     - Real.add
-    - Real.mul
     - Real.sub
     - add_neg_eq_zero
     - mul_comm
@@ -44,6 +43,18 @@ blocks:
     - add_comm
     - sub_cancels
     - sub_zero_imp_eq
+  conj_add:
+    complex:
+    - Complex.add
+    - Complex.conj
+    - Complex.im
+    - Complex.new
+    - Complex.re
+    - conj_conj
+    real:
+    - Real.add
+    - neg_distrib
+    - neg_neg
   conj_conj:
     complex:
     - Complex.conj
@@ -99,3 +110,21 @@ blocks:
     - Real.sub
     - add_comm
     - mul_comm
+  mul_one:
+    complex:
+    - Complex.1
+    - Complex.im
+    - Complex.mul
+    - Complex.new
+    - Complex.re
+    real:
+    - Real.add
+    - Real.mul
+    - Real.sub
+    - add_zero_left
+    - add_zero_right
+    - mul_comm
+    - mul_one_left
+    - mul_zero_left
+    - mul_zero_right
+    - neg_zero

--- a/build/complex.yaml
+++ b/build/complex.yaml
@@ -1,6 +1,22 @@
 dependencies: 7660433881943572148
-content: 5999666383776961504
+content: 16486769998771420253
 blocks:
+  abs_squared_conj:
+    complex:
+    - Complex.abs_squared
+    - Complex.conj
+    - Complex.im
+    - Complex.mul
+    - Complex.new
+    - Complex.re
+    real:
+    - Real.add
+    - Real.mul
+    - Real.sub
+    - add_neg_eq_zero
+    - mul_comm
+    - mul_neg_right
+    - neg_neg
   add_assoc:
     complex:
     - Complex.add

--- a/complex.ac
+++ b/complex.ac
@@ -131,3 +131,12 @@ theorem conj_conj(a: Complex) { a.conj.conj = a } by {
     a.conj.conj = Complex.new(a.re, a.im)
     a.conj.conj = a
 }
+
+// Absolute value properties
+theorem abs_squared_conj(a: Complex) { a * a.conj = Complex.new(a.abs_squared, Real.0) } by {
+    a * a.conj = Complex.new(a.re, a.im) * Complex.new(a.re, -a.im)
+    a * a.conj = Complex.new(a.re * a.re - a.im * (-a.im), a.re * (-a.im) + a.im * a.re)
+    a * a.conj = Complex.new(a.re * a.re + a.im * a.im, a.re * (-a.im) + a.im * a.re)
+    a * a.conj = Complex.new(a.re * a.re + a.im * a.im, Real.0)
+    a * a.conj = Complex.new(a.abs_squared, Real.0)
+}

--- a/complex.ac
+++ b/complex.ac
@@ -145,13 +145,13 @@ theorem abs_squared_conj(a: Complex) { a * a.conj = Complex.new(a.abs_squared, R
 theorem mul_one(a: Complex) { a * Complex.1 = a } by {
     // Expand the multiplication
     a * Complex.1 = a * Complex.new(Real.1, Real.0)
-    
+
     // Apply the definition of complex multiplication
     a * Complex.1 = Complex.new(
         a.re * Real.1 - a.im * Real.0,
         a.re * Real.0 + a.im * Real.1
     )
-    
+
     // Simplify using real number properties
     a * Complex.1 = Complex.new(a.re, a.im)
     a * Complex.1 = a
@@ -162,9 +162,9 @@ theorem conj_add(a: Complex, b: Complex) { (a + b).conj = a.conj + b.conj } by {
     (a + b).conj = Complex.new(a.re + b.re, a.im + b.im).conj
     (a + b).conj = Complex.new(a.re + b.re, -(a.im + b.im))
     (a + b).conj = Complex.new(a.re + b.re, -a.im + -b.im)
-    
+
     a.conj + b.conj = Complex.new(a.re, -a.im) + Complex.new(b.re, -b.im)
     a.conj + b.conj = Complex.new(a.re + b.re, -a.im + -b.im)
-    
+
     (a + b).conj = a.conj + b.conj
 }

--- a/complex.ac
+++ b/complex.ac
@@ -140,3 +140,31 @@ theorem abs_squared_conj(a: Complex) { a * a.conj = Complex.new(a.abs_squared, R
     a * a.conj = Complex.new(a.re * a.re + a.im * a.im, Real.0)
     a * a.conj = Complex.new(a.abs_squared, Real.0)
 }
+
+// Multiplicative identity
+theorem mul_one(a: Complex) { a * Complex.1 = a } by {
+    // Expand the multiplication
+    a * Complex.1 = a * Complex.new(Real.1, Real.0)
+    
+    // Apply the definition of complex multiplication
+    a * Complex.1 = Complex.new(
+        a.re * Real.1 - a.im * Real.0,
+        a.re * Real.0 + a.im * Real.1
+    )
+    
+    // Simplify using real number properties
+    a * Complex.1 = Complex.new(a.re, a.im)
+    a * Complex.1 = a
+}
+
+// Conjugate distribution over addition
+theorem conj_add(a: Complex, b: Complex) { (a + b).conj = a.conj + b.conj } by {
+    (a + b).conj = Complex.new(a.re + b.re, a.im + b.im).conj
+    (a + b).conj = Complex.new(a.re + b.re, -(a.im + b.im))
+    (a + b).conj = Complex.new(a.re + b.re, -a.im + -b.im)
+    
+    a.conj + b.conj = Complex.new(a.re, -a.im) + Complex.new(b.re, -b.im)
+    a.conj + b.conj = Complex.new(a.re + b.re, -a.im + -b.im)
+    
+    (a + b).conj = a.conj + b.conj
+}


### PR DESCRIPTION
## Summary
- Adds new abs_squared_conj theorem: proves a complex number times its conjugate equals its absolute value squared
- Adds mul_one theorem: proves the multiplicative identity property for complex numbers
- Adds conj_add theorem: proves conjugate distributes over addition
- Updates build configuration to include the new theorem dependencies

## Properties Added
- abs_squared_conj: z·z̄ = |z|²
- mul_one: z·1 = z
- conj_add: (z₁ + z₂)̄ = z̄₁ + z̄₂